### PR TITLE
:bug: fix Dockerfile tp run gulp generate dist dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN yarn --pure-lockfile
 # copy all file from current dir to /app in container
 COPY . /app/
 
+# Generate the dist dir with the deploy artifacts
+RUN yarn run build
+
 FROM node:16.13.2-alpine3.14
 
 WORKDIR /app


### PR DESCRIPTION
The build fails with the following:

### What is the current behavior?
>i.e. We didn't have a button to do the thing, so we needed to add a button to do the thing
- Couldn't build the template

### What is the new behavior?
>i.e. Added a button to do the thing and also handled edge-cases
- The Docker build works now

### What else was added outside of the scope of the ask?
>i.e. Simple bugfix, corrected typos, cleaned up code, etc
- bugfix

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
>i.e. Users need to update their `.env` files with the following... etc
- N/A

### Manual test cases?
>Steps to manually test introduced changes can go here.
>Remember the prerequisites!
>Remember edge-cases you've caught in your code, etc..
> i.e. ignoring the button and clicking on the "NEXT" button should trigger a warning event because the thing that clicking the new button does didn't happen
- Just run docker-compose build 

### Any additional context/background?
>N/A if this is straight-forward
- N/A

### Screenshots (if appropriate):
- SEE LOGS BELOW

# 🐞 🔊 Build Logs 

> **ERROR**: The error is because the build hasn't built the dist dir... The reason why is that gulp builds it... The fix makes it work!

```console
$ docker-compose build
Building kraken-btc-data-watcher
[+] Building 1.5s (12/13)                                                                                                                                                                                                                                                          
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                             0.0s
 => => transferring context: 35B                                                                                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/node:16.13.2-alpine3.14                                                                                                                                                                                                    0.4s
 => [builder 1/6] FROM docker.io/library/node:16.13.2-alpine3.14@sha256:d5ff6716e21e03983f8522b6e84f15f50a56e183085553e96d2801fc45dc3c74                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                                                             0.0s
 => => transferring context: 8.57kB                                                                                                                                                                                                                                           0.0s
 => CACHED [stage-1 2/4] WORKDIR /app                                                                                                                                                                                                                                         0.0s
 => CACHED [builder 2/6] RUN mkdir -p /app                                                                                                                                                                                                                                    0.0s
 => CACHED [builder 3/6] WORKDIR /app                                                                                                                                                                                                                                         0.0s
 => CACHED [builder 4/6] ADD package.json yarn.lock /app/                                                                                                                                                                                                                     0.0s
 => CACHED [builder 5/6] RUN yarn --pure-lockfile                                                                                                                                                                                                                             0.0s
 => [builder 6/6] COPY . /app/                                                                                                                                                                                                                                                0.0s
 => ERROR [stage-1 3/4] COPY --from=builder /app/dist ./dist                                                                                                                                                                                                                  0.0s
------
 > [stage-1 3/4] COPY --from=builder /app/dist ./dist:
------
failed to compute cache key: "/app/dist" not found: not found
ERROR: Service 'btc-data-watcher' failed to build : Build failed
```

# 🎉  🔊 Build Fix Logs

> **BUGFIX**: The docker image now can be built

```console
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                             0.0s
 => => transferring context: 35B                                                                                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/node:16.13.2-alpine3.14                                                                                                                                                                                                    0.4s
 => importing cache manifest from marcellodesales/kraken-blockchain-btc-transactions-file-watcher-build                                                                                                                                                                       0.0s
 => [builder 1/7] FROM docker.io/library/node:16.13.2-alpine3.14@sha256:d5ff6716e21e03983f8522b6e84f15f50a56e183085553e96d2801fc45dc3c74                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                                                             0.0s
 => => transferring context: 7.36kB                                                                                                                                                                                                                                           0.0s
 => CACHED [stage-1 2/4] WORKDIR /app                                                                                                                                                                                                                                         0.0s
 => CACHED [builder 2/7] RUN mkdir -p /app                                                                                                                                                                                                                                    0.0s
 => CACHED [builder 3/7] WORKDIR /app                                                                                                                                                                                                                                         0.0s
 => CACHED [builder 4/7] ADD package.json yarn.lock /app/                                                                                                                                                                                                                     0.0s
 => CACHED [builder 5/7] RUN yarn --pure-lockfile                                                                                                                                                                                                                             0.0s
 => CACHED [builder 6/7] COPY . /app/                                                                                                                                                                                                                                         0.0s
 => CACHED [builder 7/7] RUN yarn run build                                                                                                                                                                                                                                   0.0s
 => [stage-1 3/4] COPY --from=builder /app/dist ./dist                                                                                                                                                                                                                        0.0s
 => [stage-1 4/4] COPY --from=builder /app/node_modules ./node_modules                                                                                                                                                                                                        2.1s
 => exporting to image                                                                                                                                                                                                                                                        2.8s
 => => exporting layers                                                                                                                                                                                                                                                       2.8s
 => => writing image sha256:6b64f10616c8dc0ac58913e2e2130a1024ca5077a29890356d3b2340e58c33d4                                                                                                                                                                                  0.0s
 => => naming to docker.io/marcellodesales/kraken-blockchain-btc-transactions-file-watcher   
```
